### PR TITLE
script.module.simplejson is not optional

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,7 +8,7 @@
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="xbmc.json" version="6.0.0"/>
         <import addon="xbmc.addon" version="12.0.0"/>
-        <import addon="script.module.simplejson" version="2.0.10" optional="true"/>
+        <import addon="script.module.simplejson" version="2.0.10"/>
     </requires>
     <extension point="xbmc.python.pluginsource" library="default.py">
         <provides>video</provides>


### PR DESCRIPTION
script.module.simplejson is not optional
script.module.simplejson n'est pas facultatif

```
17:47:59 T:18446744073138014512   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.ImportError'>
                                            Error Contents: No module named simplejson
                                            Traceback (most recent call last):
                                              File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.telequebec/default.py", line 12, in <module>
                                                import os, time, urllib, urllib2, re, socket, sys, traceback, xbmcplugin, xbmcaddon, xbmcgui, xbmc, simplejson
                                            ImportError: No module named simplejson
                                            -->End of Python script error report<--
17:47:59 T:18446744073164519728   ERROR: static bool XFILE::CDirectory::GetDirectory(const CURL&, CFileItemList&, const XFILE::CDirectory::CHints&, bool) - Error getting plugin://plugin.video.telequebec/
17:47:59 T:18446744073164519728   ERROR: CGUIMediaWindow::GetDirectory(plugin://plugin.video.telequebec/) failed
```